### PR TITLE
Mid registrar per device expires

### DIFF
--- a/modules/mid_registrar/README
+++ b/modules/mid_registrar/README
@@ -57,6 +57,8 @@ mid_registrar Module
               1.5.30. pn_skip_pn_interval (integer)
               1.5.31. pn_refresh_timeout (integer)
               1.5.32. pn_enable_purr (boolean)
+              1.5.33. min_expires_avp (string)
+              1.5.34. max_expires_avp (string)
 
         1.6. Exported Functions
 
@@ -120,6 +122,8 @@ mid_registrar Module
    1.30. Setting the pn_skip_pn_interval parameter
    1.31. Setting the pn_refresh_timeout parameter
    1.32. Setting the pn_enable_purr parameter
+   1.33. Setting the min_expires_avp module parameter
+   1.34. Setting the max_expires_avp module parameter
    1.33. mid_registrar_save usage
    1.34. mid_registrar_lookup usage
    1.35. async pn_process_purr() usage
@@ -946,10 +950,41 @@ modparam("mid_registrar", "pn_refresh_timeout", 10)
 
    Default value is false.
 
-   Example 1.32. Setting the pn_enable_purr parameter
+Example 1.32. Setting the pn_enable_purr parameter
 ...
 modparam("mid_registrar", "pn_enable_purr", true)
 ...
+
+1.5.33. min_expires_avp (string)
+
+   Optional pseudo-variable specification evaluated for each REGISTER
+   processed by mid_registrar_save(). If it resolves to a positive
+   integer, the value overrides the effective minimum expiry used when
+   clamping Contact "expires" parameters or the Expires header field for
+   that specific request. Non-integer, NULL or non-positive results are
+   ignored and the existing minimum (from either the global
+   min_expires parameter or per-call flags) is preserved.
+
+   Default value is NULL (unset).
+
+   Example 1.33. Setting the min_expires_avp module parameter
+modparam("mid_registrar", "min_expires_avp", "$avp(mr_min)")
+
+1.5.34. max_expires_avp (string)
+
+   Optional pseudo-variable specification evaluated per REGISTER to
+   override the effective maximum expiry. When it resolves to a positive
+   integer, the value supersedes the current maximum (from the global
+   max_expires parameter or per-call flags) before the module clamps the
+   UA supplied expires interval. Non-integer, NULL or non-positive
+   results are ignored. If the resulting minimum exceeds the maximum,
+   the minimum will be clamped to the maximum and a warning will be
+   logged.
+
+   Default value is NULL (unset).
+
+   Example 1.34. Setting the max_expires_avp module parameter
+modparam("mid_registrar", "max_expires_avp", "$avp(mr_max)")
 
 1.6. Exported Functions
 

--- a/modules/mid_registrar/doc/mid_registrar_admin.xml
+++ b/modules/mid_registrar/doc/mid_registrar_admin.xml
@@ -605,6 +605,52 @@ modparam("mid_registrar", "max_expires", 7200)
 </programlisting>
 		</example>
 	</section>
+	<section id="param_min_expires_avp" xreflabel="min_expires_avp">
+		<title><varname>min_expires_avp</varname> (string)</title>
+		<para>
+		Optional pseudo-variable specification evaluated during
+		<xref linkend="func_mid_registrar_save"/>. If it resolves to a positive
+		integer, the value overrides the effective minimum expiry for that
+		REGISTER before the module clamps Contact <quote>expires</quote>
+		parameters or the Expires header field. NULL, non-integer or
+		non-positive results are ignored and the existing minimum remains in
+		effect.
+		</para>
+		<para>
+		Default value is <emphasis role='bold'>NULL</emphasis> (unset)
+		</para>
+		<example>
+		<title>Setting the <emphasis>min_expires_avp</emphasis> module parameter</title>
+		<programlisting format="linespecific">
+modparam("mid_registrar", "min_expires_avp", "$avp(mr_min)")
+</programlisting>
+		</example>
+	</section>
+	<section id="param_max_expires_avp" xreflabel="max_expires_avp">
+		<title><varname>max_expires_avp</varname> (string)</title>
+		<para>
+		Optional pseudo-variable specification evaluated per REGISTER to
+		override the effective maximum expiry. When it resolves to a positive
+		integer, the value supersedes the current maximum before clamping takes
+		place. NULL, non-integer or non-positive results are ignored.
+		</para>
+		<para>
+		If the resulting minimum exceeds the maximum, the module clamps the
+		minimum to the maximum and logs a warning. The internal
+		<varname>default_expires</varname> value is also clamped into the final
+		effective window so that REGISTER requests without explicit Expires
+		information honour the override.
+		</para>
+		<para>
+		Default value is <emphasis role='bold'>NULL</emphasis> (unset)
+		</para>
+		<example>
+		<title>Setting the <emphasis>max_expires_avp</emphasis> module parameter</title>
+		<programlisting format="linespecific">
+modparam("mid_registrar", "max_expires_avp", "$avp(mr_max)")
+</programlisting>
+		</example>
+	</section>
 	<section id="param_default_q" xreflabel="default_q">
 		<title><varname>default_q</varname> (integer)</title>
 		<para>
@@ -1165,4 +1211,3 @@ if (is_method("REGISTER")) {
 
 
 </chapter>
-

--- a/modules/mid_registrar/mid_registrar.c
+++ b/modules/mid_registrar/mid_registrar.c
@@ -70,6 +70,11 @@ int min_expires     = 10;   /*!< Minimum expires the phones are allowed to use
 							  in seconds - use 0 to switch expires checking off */
 int max_expires     = 3600;
 
+str min_expires_avp_param = {0, 0};
+str max_expires_avp_param = {0, 0};
+pv_spec_t min_expires_avp;
+pv_spec_t max_expires_avp;
+
 int retry_after = 0;		/*!< The value of Retry-After HF in 5xx replies */
 
 qvalue_t default_q  = Q_UNSPECIFIED; /*!< Default q value multiplied by 1000 */
@@ -153,6 +158,8 @@ static param_export_t mod_params[] = {
 	{ "default_expires",      INT_PARAM, &default_expires },
 	{ "min_expires",          INT_PARAM, &min_expires },
 	{ "max_expires",          INT_PARAM, &max_expires },
+	{ "min_expires_avp",     STR_PARAM, &min_expires_avp_param.s },
+	{ "max_expires_avp",     STR_PARAM, &max_expires_avp_param.s },
 	{ "default_q",            INT_PARAM, &default_q },
 	{ "tcp_persistent_flag",  STR_PARAM, &tcp_persistent_flag_s },
 	{ "realm_prefix",         STR_PARAM, &realm_prefix.s },
@@ -593,6 +600,26 @@ int solve_avp_defs(void)
 			if (!pv_parse_spec(&extra_ct_params_str, &extra_ct_params_avp) ||
 			     extra_ct_params_avp.type != PVT_AVP) {
 				LM_ERR("extra_ct_params_avp: malformed or non-AVP content!\n");
+				return -1;
+			}
+		}
+	}
+
+	if (min_expires_avp_param.s) {
+		min_expires_avp_param.len = strlen(min_expires_avp_param.s);
+		if (min_expires_avp_param.len) {
+			if (!pv_parse_spec(&min_expires_avp_param, &min_expires_avp)) {
+				LM_ERR("malformed min_expires_avp PV definition\n");
+				return -1;
+			}
+		}
+	}
+
+	if (max_expires_avp_param.s) {
+		max_expires_avp_param.len = strlen(max_expires_avp_param.s);
+		if (max_expires_avp_param.len) {
+			if (!pv_parse_spec(&max_expires_avp_param, &max_expires_avp)) {
+				LM_ERR("malformed max_expires_avp PV definition\n");
 				return -1;
 			}
 		}

--- a/modules/mid_registrar/mid_registrar.c
+++ b/modules/mid_registrar/mid_registrar.c
@@ -500,6 +500,9 @@ struct mid_reg_info *mri_dup(struct mid_reg_info *mri)
 		shm_str_dup(&new->main_reg_next_hop, &mri->main_reg_next_hop);
 
 	new->pn_provider_state = mri->pn_provider_state;
+	new->eff_min_expires = mri->eff_min_expires;
+	new->eff_max_expires = mri->eff_max_expires;
+	new->eff_default_expires = mri->eff_default_expires;
 
 	new->cmatch.mode = mri->cmatch.mode;
 	if (mri->cmatch.match_params)

--- a/modules/mid_registrar/mid_registrar.h
+++ b/modules/mid_registrar/mid_registrar.h
@@ -91,6 +91,11 @@ struct mid_reg_info {
 	int expires_out; /* [NEW] outgoing expires value (not a unix TS!) */
 	                 /* used to absorb/relay new REGISTERs */
 
+	/* effective expires policy for this REGISTER */
+	int eff_min_expires;
+	int eff_max_expires;
+	int eff_default_expires;
+
 	unsigned int last_reg_ts; /* [NEW] used to absorb/relay new REGISTERs
 	                                   marks the last successful reg */
 

--- a/modules/mid_registrar/mid_registrar.h
+++ b/modules/mid_registrar/mid_registrar.h
@@ -32,6 +32,7 @@
 
 #include "../../parser/msg_parser.h"
 #include "../../parser/contact/contact.h"
+#include "../../pvar.h"
 #include "../../script_cb.h"
 #include "../../socket_info.h"
 
@@ -126,6 +127,9 @@ extern struct sig_binds sig_api;
 
 extern int retry_after;
 extern unsigned int outgoing_expires;
+
+extern pv_spec_t min_expires_avp;
+extern pv_spec_t max_expires_avp;
 
 extern enum mid_reg_mode reg_mode;
 extern enum mid_reg_insertion_mode ctid_insertion;

--- a/modules/mid_registrar/save.c
+++ b/modules/mid_registrar/save.c
@@ -39,6 +39,7 @@
 #include "../../parser/parse_methods.h"
 #include "../../parser/parse_supported.h"
 #include "../../parser/parse_allow.h"
+#include "../../parser/parse_expires.h"
 #include "../../dset.h"
 
 #include "../../parser/parse_from.h"
@@ -47,6 +48,7 @@
 #include "../../data_lump.h"
 #include "../../data_lump_rpl.h"
 #include "../../lib/reg/common.h"
+#include "../../pvar.h"
 
 #include "../../trim.h"
 #include "../../strcommon.h"
@@ -69,22 +71,45 @@ int prepare_rpl_path(struct sip_msg *req, str *path, int flags, struct sip_msg *
  * @_e: output param (integer) - value of the ";expires" Contact hf param or "Expires" hf
  */
 void calc_contact_expires(struct sip_msg* _m, param_t* _ep, int* _e,
-                          int enforce_expires_limits)
+			  int enforce_expires_limits, struct save_ctx *sctx)
 {
+	int eff_min = min_expires;
+	int eff_max = max_expires;
+	int eff_default = default_expires;
+	int use_local = enforce_expires_limits && sctx;
+
+	if (use_local) {
+		if (sctx->min_expires)
+			eff_min = sctx->min_expires;
+		if (sctx->max_expires)
+			eff_max = sctx->max_expires;
+		if (sctx->expires)
+			eff_default = sctx->expires;
+	}
+
 	if (!_ep || !_ep->body.len) {
-		*_e = get_expires_hf(_m);
+		if (_m->expires) {
+			exp_body_t *p = (exp_body_t *)_m->expires->parsed;
+			if (p && p->valid) {
+				*_e = p->val;
+			} else {
+				*_e = eff_default;
+			}
+		} else {
+			*_e = eff_default;
+		}
 	} else {
 		if (str2int(&_ep->body, (unsigned int*)_e) < 0) {
-			*_e = default_expires;
+			*_e = eff_default;
 		}
 	}
 
 	if (enforce_expires_limits) {
-		if ((*_e != 0) && min_expires && ((*_e) < min_expires))
-			*_e = min_expires;
+		if ((*_e != 0) && eff_min && ((*_e) < eff_min))
+			*_e = eff_min;
 
-		if ((*_e != 0) && max_expires && ((*_e) > max_expires))
-			*_e = max_expires;
+		if ((*_e != 0) && eff_max && ((*_e) > eff_max))
+			*_e = eff_max;
 	}
 
 	LM_DBG("expires: %d\n", *_e);
@@ -118,7 +143,71 @@ void calc_ob_contact_expires(struct sip_msg* _m, param_t* _ep, int* _e,
 	LM_DBG("outgoing expires: %d\n", *_e);
 }
 
-static int trim_to_single_contact(struct sip_msg *msg, str *aor, int expires)
+
+static void apply_expires_overrides(struct sip_msg *msg, struct save_ctx *sctx)
+{
+	pv_value_t pv;
+	int eff_min = sctx->min_expires;
+	int eff_max = sctx->max_expires;
+	int eff_default = sctx->expires ? sctx->expires : default_expires;
+	int clamped_default = eff_default;
+
+	if (min_expires_avp.getf) {
+		memset(&pv, 0, sizeof(pv));
+		if (pv_get_spec_value(msg, &min_expires_avp, &pv) == 0) {
+			if (pvv_is_int(&pv) && pv.ri > 0) {
+				eff_min = pv.ri;
+			} else if (!(pv.flags & PV_VAL_NULL)) {
+				LM_DBG("ignoring min_expires_avp override (value=%d flags=%d)\n",
+				        pv.ri, pv.flags);
+			}
+		} else {
+			LM_DBG("failed to resolve min_expires_avp override\n");
+		}
+	}
+
+	if (max_expires_avp.getf) {
+		memset(&pv, 0, sizeof(pv));
+		if (pv_get_spec_value(msg, &max_expires_avp, &pv) == 0) {
+			if (pvv_is_int(&pv) && pv.ri > 0) {
+				eff_max = pv.ri;
+			} else if (!(pv.flags & PV_VAL_NULL)) {
+				LM_DBG("ignoring max_expires_avp override (value=%d flags=%d)\n",
+				        pv.ri, pv.flags);
+			}
+		} else {
+			LM_DBG("failed to resolve max_expires_avp override\n");
+		}
+	}
+
+	if (eff_max > 0 && eff_min > eff_max) {
+		LM_WARN("effective min_expires (%d) greater than max_expires (%d); "
+		        "clamping min to %d\n", eff_min, eff_max, eff_max);
+		eff_min = eff_max;
+	}
+
+	if (eff_min && clamped_default < eff_min) {
+		LM_WARN("default_expires (%d) below effective min_expires (%d); "
+		        "raising to %d\n", eff_default, eff_min, eff_min);
+		clamped_default = eff_min;
+	}
+
+	if (eff_max && clamped_default > eff_max) {
+		LM_WARN("default_expires (%d) above effective max_expires (%d); "
+		        "lowering to %d\n", eff_default, eff_max, eff_max);
+		clamped_default = eff_max;
+	}
+
+	LM_DBG("effective expires window: min=%d max=%d default=%d\n",
+	       eff_min, eff_max, clamped_default);
+
+	sctx->min_expires = eff_min;
+	sctx->max_expires = eff_max;
+	sctx->expires = clamped_default;
+}
+
+static int trim_to_single_contact(struct sip_msg *msg, str *aor, int expires,
+				 struct save_ctx *sctx)
 {
 	contact_t *c = NULL;
 	struct socket_info *send_sock;
@@ -150,7 +239,7 @@ static int trim_to_single_contact(struct sip_msg *msg, str *aor, int expires)
 
 	for (c = ((contact_body_t *)ct->parsed)->contacts; c;
 	     c = get_next_contact(c)) {
-		calc_contact_expires(msg, c->expires, &e, 1);
+		calc_contact_expires(msg, c->expires, &e, 1, sctx);
 		if (e != 0)
 			is_dereg = 0;
 
@@ -530,14 +619,15 @@ static int replace_expires(contact_t *c, struct sip_msg *msg, int new_expires,
 	return 0;
 }
 
-void overwrite_contact_expirations(struct sip_msg *req, struct mid_reg_info *mri)
+void overwrite_contact_expirations(struct sip_msg *req, struct mid_reg_info *mri,
+				       struct save_ctx *sctx)
 {
 	contact_t *c;
 	int e, expiry_tick, new_expires;
 	int exp_header_done = 0;
 
 	for (c = get_first_contact(req); c; c = get_next_contact(c)) {
-		calc_contact_expires(req, c->expires, &e, 1);
+		calc_contact_expires(req, c->expires, &e, 1, sctx);
 		calc_ob_contact_expires(req, c->expires, &expiry_tick, mri->expires_out);
 		new_expires = expiry_tick == 0 ? 0 : expiry_tick - get_act_time();
 
@@ -552,7 +642,8 @@ void overwrite_contact_expirations(struct sip_msg *req, struct mid_reg_info *mri
 	}
 }
 
-int dup_req_info(struct sip_msg *req, struct mid_reg_info *mri)
+int dup_req_info(struct sip_msg *req, struct mid_reg_info *mri,
+		struct save_ctx *sctx)
 {
 	contact_t *c;
 	struct ct_mapping *ctmap;
@@ -594,7 +685,7 @@ int dup_req_info(struct sip_msg *req, struct mid_reg_info *mri)
 		}
 
 		update_act_time();
-		calc_contact_expires(req, c->expires, &ctmap->expires, 1);
+		calc_contact_expires(req, c->expires, &ctmap->expires, 1, sctx);
 
 		/* q */
 		if (calc_contact_q(c->q, &ctmap->q) < 0) {
@@ -684,11 +775,11 @@ void mid_reg_req_fwded(struct cell *_, int __, struct tmcb_params *params)
 		goto out;
 
 	if (reg_mode != MID_REG_MIRROR)
-		overwrite_contact_expirations(req, mri);
+		overwrite_contact_expirations(req, mri, sctx);
 
 	if (reg_mode == MID_REG_THROTTLE_AOR) {
 		LM_DBG("trimming all Contact URIs into one...\n");
-		if (trim_to_single_contact(req, &mri->aor, mri->expires_out)) {
+		if (trim_to_single_contact(req, &mri->aor, mri->expires_out, sctx)) {
 			LM_ERR("failed to overwrite Contact URI\n");
 			goto out;
 		}
@@ -703,7 +794,7 @@ void mid_reg_req_fwded(struct cell *_, int __, struct tmcb_params *params)
 	 * earliest, before sending out the request and almost ignore the
 	 * un-parsable "req" sip_msg provided during TMCB_RESPONSE_IN.
 	 */
-	if (dup_req_info(req, mri) != 0) {
+	if (dup_req_info(req, mri, sctx) != 0) {
 		LM_ERR("oom\n");
 		goto out;
 	}
@@ -1549,7 +1640,7 @@ static inline int save_restore_req_contacts(struct sip_msg *req,
 	/* in MID_REG_THROTTLE_AOR mode, any reply will only contain 1 contact */
 	_c = get_first_contact(rpl);
 	if (_c)
-		calc_contact_expires(rpl, _c->expires, &e_out, 0);
+		calc_contact_expires(rpl, _c->expires, &e_out, 0, NULL);
 
 	ul.lock_udomain(mri->dom, &mri->aor);
 	ul.get_urecord(mri->dom, &mri->aor, &r);
@@ -2203,7 +2294,7 @@ static int process_contacts_by_ct(struct sip_msg *msg, urecord_t *urec,
 
 	/* if there are any new contacts, we must return a "forward" code */
 	for (ct = get_first_contact(msg); ct; ct = get_next_contact(ct)) {
-		calc_contact_expires(msg, ct->expires, &e, 1);
+		calc_contact_expires(msg, ct->expires, &e, 1, _sctx);
 		if (e == 0) {
 			LM_DBG("forwarding REGISTER (ct with expires == 0)\n");
 			return 1;
@@ -2388,7 +2479,7 @@ static int process_contacts_by_aor(struct sip_msg *req, urecord_t *urec,
 
 	/* if there are any new contacts, we must return a "forward" code */
 	for (ct = get_first_contact(req); ct; ct = get_next_contact(ct)) {
-		calc_contact_expires(req, ct->expires, &e, 1);
+		calc_contact_expires(req, ct->expires, &e, 1, _sctx);
 		if (e > e_out) {
 			LM_DBG("reducing contact expiration from %d sec to %d sec!\n",
 			       e, e_out);
@@ -2539,12 +2630,17 @@ int mid_reg_save(struct sip_msg *msg, udomain_t *d, str *flags_str,
 	rerrno = R_FINE;
 	memset(&sctx, 0, sizeof sctx);
 	sctx.cmatch.mode = CT_MATCH_NONE;
+	sctx.min_expires = min_expires;
+	sctx.max_expires = max_expires;
+	sctx.expires = default_expires;
 	sctx.max_contacts = max_contacts;
 
 	LM_DBG("saving to %.*s...\n", d->name->len, d->name->s);
 
 	if (flags_str)
 		reg_parse_save_flags(flags_str, &sctx);
+
+	apply_expires_overrides(msg, &sctx);
 
 	if (parse_reg_headers(msg) != 0) {
 		LM_ERR("failed to parse req headers\n");

--- a/modules/mid_registrar/save.c
+++ b/modules/mid_registrar/save.c
@@ -745,6 +745,12 @@ void mid_reg_req_fwded(struct cell *_, int __, struct tmcb_params *params)
 	struct sip_msg *req = params->req;
 	struct mid_reg_info *mri = *(struct mid_reg_info **)(params->param);
 	str *next_hop = NULL;
+	struct save_ctx override_ctx;
+
+	memset(&override_ctx, 0, sizeof override_ctx);
+	override_ctx.min_expires = mri->eff_min_expires;
+	override_ctx.max_expires = mri->eff_max_expires;
+	override_ctx.expires = mri->eff_default_expires;
 
 	lock_start_write(mri->tm_lock);
 
@@ -775,11 +781,12 @@ void mid_reg_req_fwded(struct cell *_, int __, struct tmcb_params *params)
 		goto out;
 
 	if (reg_mode != MID_REG_MIRROR)
-		overwrite_contact_expirations(req, mri, sctx);
+		overwrite_contact_expirations(req, mri, &override_ctx);
 
 	if (reg_mode == MID_REG_THROTTLE_AOR) {
 		LM_DBG("trimming all Contact URIs into one...\n");
-		if (trim_to_single_contact(req, &mri->aor, mri->expires_out, sctx)) {
+		if (trim_to_single_contact(req, &mri->aor, mri->expires_out,
+		                          &override_ctx)) {
 			LM_ERR("failed to overwrite Contact URI\n");
 			goto out;
 		}
@@ -794,7 +801,7 @@ void mid_reg_req_fwded(struct cell *_, int __, struct tmcb_params *params)
 	 * earliest, before sending out the request and almost ignore the
 	 * un-parsable "req" sip_msg provided during TMCB_RESPONSE_IN.
 	 */
-	if (dup_req_info(req, mri, sctx) != 0) {
+	if (dup_req_info(req, mri, &override_ctx) != 0) {
 		LM_ERR("oom\n");
 		goto out;
 	}
@@ -2032,6 +2039,10 @@ static int prepare_forward(struct sip_msg *msg, udomain_t *d,
 		if (!mri->cmatch.match_params)
 			goto oom;
 	}
+
+	mri->eff_min_expires = sctx->min_expires;
+	mri->eff_max_expires = sctx->max_expires;
+	mri->eff_default_expires = sctx->expires;
 
 	if (parse_from_header(msg) != 0) {
 		LM_ERR("failed to parse From hf\n");


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Per-REGISTER overrides for minimum and maximum registration expiry via new parameters: min_expires_avp and max_expires_avp.
  - Effective expiry window now honored when saving/forwarding REGISTER requests, with improved default expiry clamping.
- Documentation
  - Added detailed guidance and examples for min_expires_avp and max_expires_avp, including interaction with existing expiry settings.
  - Minor formatting cleanup in parameter examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->