### PR TITLE
mid_registrar: per-request expires overrides (3.6 backport)

### DIFF
--- a/modules/mid_registrar/README
+++ b/modules/mid_registrar/README
@@ -58,6 +58,8 @@ mid_registrar Module
               1.5.31. pn_skip_pn_interval (integer)
               1.5.32. pn_refresh_timeout (integer)
               1.5.33. pn_enable_purr (boolean)
+              1.5.34. min_expires_avp (string)
+              1.5.35. max_expires_avp (string)
 
         1.6. Exported Functions
 
@@ -122,9 +124,11 @@ mid_registrar Module
    1.31. Setting the pn_skip_pn_interval parameter
    1.32. Setting the pn_refresh_timeout parameter
    1.33. Setting the pn_enable_purr parameter
-   1.34. mid_registrar_save usage
-   1.35. mid_registrar_lookup usage
-   1.36. async pn_process_purr() usage
+   1.34. Setting the min_expires_avp module parameter
+   1.35. Setting the max_expires_avp module parameter
+   1.36. mid_registrar_save usage
+   1.37. mid_registrar_lookup usage
+   1.38. async pn_process_purr() usage
 
 Chapter 1. Admin Guide
 
@@ -980,9 +984,40 @@ modparam("mid_registrar", "pn_refresh_timeout", 10)
 modparam("mid_registrar", "pn_enable_purr", true)
 ...
 
+1.5.34. min_expires_avp (string)
+
+   Optional pseudo-variable specification evaluated for each REGISTER
+   processed by mid_registrar_save(). If it resolves to a positive
+   integer, the value overrides the effective minimum expiry used when
+   clamping Contact "expires" parameters or the Expires header field for
+   that specific request. Non-integer, NULL or non-positive results are
+   ignored and the existing minimum (from either the global
+   min_expires parameter or per-call flags) is preserved.
+
+   Default value is NULL (unset).
+
+   Example 1.34. Setting the min_expires_avp module parameter
+modparam("mid_registrar", "min_expires_avp", "$avp(mr_min)")
+
+1.5.35. max_expires_avp (string)
+
+   Optional pseudo-variable specification evaluated per REGISTER to
+   override the effective maximum expiry. When it resolves to a positive
+   integer, the value supersedes the current maximum (from the global
+   max_expires parameter or per-call flags) before the module clamps the
+   UA supplied expires interval. Non-integer, NULL or non-positive
+   results are ignored. If the resulting minimum exceeds the maximum,
+   the minimum will be clamped to the maximum and a warning will be
+   logged.
+
+   Default value is NULL (unset).
+
+   Example 1.35. Setting the max_expires_avp module parameter
+modparam("mid_registrar", "max_expires_avp", "$avp(mr_max)")
+
 1.6. Exported Functions
 
-1.6.1.  mid_registrar_save(domain[, flags[, aor[, outgoing_expires[,
+1.6.1.  mid_registrar_save(domain[, flags[, aor[, outgoing_expires[, 
 ownership_tag]]]])
 
    Function to be called when handling REGISTER requests. This
@@ -1116,7 +1151,7 @@ ownership_tag]]]])
 
    This function can only be used from the request route.
 
-   Example 1.34. mid_registrar_save usage
+   Example 1.36. mid_registrar_save usage
 ...
 if (is_method("REGISTER")) {
         mid_registrar_save("location");
@@ -1273,7 +1308,7 @@ if (is_method("REGISTER")) {
 
    This function can only be used from the request route.
 
-   Example 1.35. mid_registrar_lookup usage
+   Example 1.37. mid_registrar_lookup usage
 ...
         # initial invites from the main registrar - need to look them up
 !
@@ -1318,7 +1353,7 @@ if (is_method("REGISTER")) {
        foreign PURR or offline contact)
      * -1 - Internal Error
 
-   Example 1.36. async pn_process_purr() usage
+   Example 1.38. async pn_process_purr() usage
 route {
         ...
         if (has_totag()) {

--- a/modules/mid_registrar/doc/mid_registrar_admin.xml
+++ b/modules/mid_registrar/doc/mid_registrar_admin.xml
@@ -608,6 +608,52 @@ modparam("mid_registrar", "max_expires", 7200)
 </programlisting>
 		</example>
 	</section>
+	<section id="param_min_expires_avp" xreflabel="min_expires_avp">
+		<title><varname>min_expires_avp</varname> (string)</title>
+		<para>
+		Optional pseudo-variable specification evaluated during
+		<xref linkend="func_mid_registrar_save"/>. If it resolves to a positive
+		integer, the value overrides the effective minimum expiry for that
+		REGISTER before the module clamps Contact <quote>expires</quote>
+		parameters or the Expires header field. NULL, non-integer or
+		non-positive results are ignored and the existing minimum remains in
+		effect.
+		</para>
+		<para>
+		Default value is <emphasis role='bold'>NULL</emphasis> (unset)
+		</para>
+		<example>
+		<title>Setting the <emphasis>min_expires_avp</emphasis> module parameter</title>
+		<programlisting format="linespecific">
+modparam("mid_registrar", "min_expires_avp", "$avp(mr_min)")
+</programlisting>
+		</example>
+	</section>
+	<section id="param_max_expires_avp" xreflabel="max_expires_avp">
+		<title><varname>max_expires_avp</varname> (string)</title>
+		<para>
+		Optional pseudo-variable specification evaluated per REGISTER to
+		override the effective maximum expiry. When it resolves to a positive
+		integer, the value supersedes the current maximum before clamping takes
+		place. NULL, non-integer or non-positive results are ignored.
+		</para>
+		<para>
+		If the resulting minimum exceeds the maximum, the module clamps the
+		minimum to the maximum and logs a warning. The internal
+		<varname>default_expires</varname> value is also clamped into the final
+		effective window so that REGISTER requests without explicit Expires
+		information honour the override.
+		</para>
+		<para>
+		Default value is <emphasis role='bold'>NULL</emphasis> (unset)
+		</para>
+		<example>
+		<title>Setting the <emphasis>max_expires_avp</emphasis> module parameter</title>
+		<programlisting format="linespecific">
+modparam("mid_registrar", "max_expires_avp", "$avp(mr_max)")
+</programlisting>
+		</example>
+	</section>
 	<section id="param_default_q" xreflabel="default_q">
 		<title><varname>default_q</varname> (integer)</title>
 		<para>
@@ -1065,4 +1111,3 @@ if (is_method("REGISTER")) {
 
 
 </chapter>
-

--- a/modules/mid_registrar/mid_registrar.c
+++ b/modules/mid_registrar/mid_registrar.c
@@ -70,6 +70,11 @@ int min_expires     = 10;   /*!< Minimum expires the phones are allowed to use
 							  in seconds - use 0 to switch expires checking off */
 int max_expires     = 3600;
 
+str min_expires_avp_param = {0, 0};
+str max_expires_avp_param = {0, 0};
+pv_spec_t min_expires_avp;
+pv_spec_t max_expires_avp;
+
 int retry_after = 0;		/*!< The value of Retry-After HF in 5xx replies */
 
 qvalue_t default_q  = Q_UNSPECIFIED; /*!< Default q value multiplied by 1000 */
@@ -157,6 +162,8 @@ static const param_export_t mod_params[] = {
 	{ "default_expires",      INT_PARAM, &default_expires },
 	{ "min_expires",          INT_PARAM, &min_expires },
 	{ "max_expires",          INT_PARAM, &max_expires },
+	{ "min_expires_avp",     STR_PARAM, &min_expires_avp_param.s },
+	{ "max_expires_avp",     STR_PARAM, &max_expires_avp_param.s },
 	{ "default_q",            INT_PARAM, &default_q },
 	{ "tcp_persistent_flag",  STR_PARAM, &tcp_persistent_flag_s },
 	{ "realm_prefix",         STR_PARAM, &realm_prefix.s },
@@ -622,6 +629,26 @@ int solve_avp_defs(void)
 			if (!pv_parse_spec(&extra_ct_params_str, &extra_ct_params_avp) ||
 			     extra_ct_params_avp.type != PVT_AVP) {
 				LM_ERR("extra_ct_params_avp: malformed or non-AVP content!\n");
+				return -1;
+			}
+		}
+	}
+
+	if (min_expires_avp_param.s) {
+		min_expires_avp_param.len = strlen(min_expires_avp_param.s);
+		if (min_expires_avp_param.len) {
+			if (!pv_parse_spec(&min_expires_avp_param, &min_expires_avp)) {
+				LM_ERR("malformed min_expires_avp PV definition\n");
+				return -1;
+			}
+		}
+	}
+
+	if (max_expires_avp_param.s) {
+		max_expires_avp_param.len = strlen(max_expires_avp_param.s);
+		if (max_expires_avp_param.len) {
+			if (!pv_parse_spec(&max_expires_avp_param, &max_expires_avp)) {
+				LM_ERR("malformed max_expires_avp PV definition\n");
 				return -1;
 			}
 		}

--- a/modules/mid_registrar/mid_registrar.c
+++ b/modules/mid_registrar/mid_registrar.c
@@ -529,6 +529,9 @@ struct mid_reg_info *mri_dup(struct mid_reg_info *mri)
 		shm_str_dup(&new->main_reg_next_hop, &mri->main_reg_next_hop);
 
 	new->pn_provider_state = mri->pn_provider_state;
+	new->eff_min_expires = mri->eff_min_expires;
+	new->eff_max_expires = mri->eff_max_expires;
+	new->eff_default_expires = mri->eff_default_expires;
 
 	new->cmatch.mode = mri->cmatch.mode;
 	if (mri->cmatch.match_params)

--- a/modules/mid_registrar/mid_registrar.h
+++ b/modules/mid_registrar/mid_registrar.h
@@ -91,6 +91,11 @@ struct mid_reg_info {
 	int expires_out; /* [NEW] outgoing expires value (not a unix TS!) */
 	                 /* used to absorb/relay new REGISTERs */
 
+	/* effective expires policy for this REGISTER */
+	int eff_min_expires;
+	int eff_max_expires;
+	int eff_default_expires;
+
 	unsigned int last_reg_ts; /* [NEW] used to absorb/relay new REGISTERs
 	                                   marks the last successful reg */
 

--- a/modules/mid_registrar/mid_registrar.h
+++ b/modules/mid_registrar/mid_registrar.h
@@ -32,6 +32,7 @@
 
 #include "../../parser/msg_parser.h"
 #include "../../parser/contact/contact.h"
+#include "../../pvar.h"
 #include "../../script_cb.h"
 #include "../../socket_info.h"
 
@@ -126,6 +127,9 @@ extern struct sig_binds sig_api;
 
 extern int retry_after;
 extern unsigned int outgoing_expires;
+
+extern pv_spec_t min_expires_avp;
+extern pv_spec_t max_expires_avp;
 
 extern enum mid_reg_mode reg_mode;
 extern enum mid_reg_insertion_mode ctid_insertion;


### PR DESCRIPTION
Backport of #1 onto 3.6.

- add per-request min/max expires overrides via 
- document the new AVP-driven overrides
- fix mid_registrar request callbacks to honor per-request overrides
 
Credits: @bigx333